### PR TITLE
Exclude test files from app package

### DIFF
--- a/src/misc/appPackager.ts
+++ b/src/misc/appPackager.ts
@@ -19,6 +19,8 @@ export class AppPackager {
             '**/*.js',
             '**/*.js.map',
             '**/*.d.ts',
+            '**/*.spec.ts',
+            '**/*.test.ts',
             '**/dist/**',
             '**/.*',
         ],


### PR DESCRIPTION
The deployed version of the app should not need to contain test or spec files. 