### PR TITLE
[FIX] Deployment impossible for users with active 2FA

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -21,10 +21,14 @@ export default class Deploy extends Command {
         password: flags.string({ char: 'p', dependsOn: ['username'], description: 'password of the user' }),
         code: flags.string({ char: 'c', dependsOn: ['username'], description: '2FA code of the user' }),
         i2fa: flags.boolean({ description: 'interactively ask for 2FA code' }),
-        token: flags.string({ char: 't', dependsOn: ['userid'],
-            description: 'API token to use with UserID (instead of username & password)' }),
-        userid: flags.string({ char: 'i', dependsOn: ['token'],
-            description: 'UserID to use  with API token (instead of username & password)' }),
+        token: flags.string({
+            char: 't', dependsOn: ['userid'],
+            description: 'API token to use with UserID (instead of username & password)',
+        }),
+        userid: flags.string({
+            char: 'i', dependsOn: ['token'],
+            description: 'UserID to use with API token (instead of username & password)',
+        }),
     };
 
     public async run() {
@@ -86,9 +90,11 @@ export default class Deploy extends Command {
         let authResult;
 
         if (!flags.token) {
-            let credentials: {username: any, password: any, code?: any};
-            credentials = {username: flags.username, password: flags.password};
-            if (flags.code) { credentials.code = flags.code; }
+            let credentials: { username: string, password: string, code?: string };
+            credentials = { username: flags.username, password: flags.password };
+            if (flags.code) {
+                credentials.code = flags.code;
+            }
 
             authResult = await fetch(this.normalizeUrl(flags.url, '/api/v1/login'), {
                 method: 'POST',
@@ -115,7 +121,7 @@ export default class Deploy extends Command {
                 throw new Error('Invalid API token');
             }
 
-            authResult = { data: { authToken: flags.token, userId: flags.userid}};
+            authResult = { data: { authToken: flags.token, userId: flags.userid } };
         }
 
         let endpoint = '/api/apps';

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -19,6 +19,8 @@ export default class Deploy extends Command {
         url: flags.string({ description: 'where the App should be deployed to' }),
         username: flags.string({ char: 'u', dependsOn: ['url'], description: 'username to authenticate with' }),
         password: flags.string({ char: 'p', dependsOn: ['username'], description: 'password of the user' }),
+        code: flags.string({ char: 'c', dependsOn: ['username'], description: '2FA code of the user' }),
+        i2fa: flags.boolean({ description: 'interactively ask for 2FA code' }),
         token: flags.string({ char: 't', dependsOn: ['userid'],
             description: 'API token to use with UserID (instead of username & password)' }),
         userid: flags.string({ char: 'i', dependsOn: ['token'],
@@ -65,6 +67,10 @@ export default class Deploy extends Command {
             flags.password = await cli.prompt('And, what is the password?', { type: 'hide' });
         }
 
+        if (flags.i2fa) {
+            flags.code = await cli.prompt('2FA code', { type: 'hide' });
+        }
+
         cli.action.start(`${ chalk.green('deploying') } your app`);
 
         const data = new FormData();
@@ -80,16 +86,20 @@ export default class Deploy extends Command {
         let authResult;
 
         if (!flags.token) {
+            let credentials: {username: any, password: any, code?: any};
+            credentials = {username: flags.username, password: flags.password};
+            if (flags.code) { credentials.code = flags.code; }
+
             authResult = await fetch(this.normalizeUrl(flags.url, '/api/v1/login'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({username: flags.username, password: flags.password}),
+                body: JSON.stringify(credentials),
             }).then((res: Response) => res.json());
 
             if (authResult.status === 'error' || !authResult.data) {
-                throw new Error('Invalid username and password');
+                throw new Error('Invalid username and password or missing 2FA code (if active)');
             }
         } else {
             const verificationResult = await fetch(this.normalizeUrl(flags.url, '/api/v1/me'), {


### PR DESCRIPTION
I added 2FA compatibility to the authentication process for the `deploy` command.

I also added the ability to authenticate with a user generated API token and the user ID instead of username and password. I thought it was much nicer and safer to have a token (that you can delete) in your CLI history / your `env` files instead of your plaintext password.
With this users with activated 2FA can also simply use a token to authenticate, which in my opinion is much less tedious than getting a 2FA code everytime you want to deploy.

Let me know if I you need me to do any modifications to merge this!

Have a nice day 👋🏻