### PR TITLE
Fix building package on windows

### DIFF
--- a/src/misc/appPackager.ts
+++ b/src/misc/appPackager.ts
@@ -46,7 +46,7 @@ export class AppPackager {
             throw new Error('No files to package were found');
         }
 
-        const zipName = path.join('dist',`${this.fd.info.nameSlug}_${this.fd.info.version}.zip`);
+        const zipName = path.join('dist', `${this.fd.info.nameSlug}_${this.fd.info.version}.zip`);
         const zip = new Yazl.ZipFile();
 
         zip.addBuffer(Buffer.from(JSON.stringify(AppPackager.PackagerInfo)), '.packagedby', { compress: true });

--- a/src/misc/appPackager.ts
+++ b/src/misc/appPackager.ts
@@ -46,13 +46,13 @@ export class AppPackager {
             throw new Error('No files to package were found');
         }
 
-        const zipName = `dist${ path.sep }${ this.fd.info.nameSlug }_${ this.fd.info.version}.zip`;
+        const zipName = path.join('dist',`${this.fd.info.nameSlug}_${this.fd.info.version}.zip`);
         const zip = new Yazl.ZipFile();
 
         zip.addBuffer(Buffer.from(JSON.stringify(AppPackager.PackagerInfo)), '.packagedby', { compress: true });
 
         for (const realPath of matches) {
-            const zipPath = realPath.replace(this.fd.folder + path.sep, '');
+            const zipPath = path.relative(this.fd.folder + path.sep,realPath)
             const fileStat = await fs.stat(realPath);
 
             const options: Partial<Yazl.Options> = {

--- a/src/misc/appPackager.ts
+++ b/src/misc/appPackager.ts
@@ -52,7 +52,7 @@ export class AppPackager {
         zip.addBuffer(Buffer.from(JSON.stringify(AppPackager.PackagerInfo)), '.packagedby', { compress: true });
 
         for (const realPath of matches) {
-            const zipPath = path.relative(this.fd.folder + path.sep,realPath)
+            const zipPath = path.relative(this.fd.folder, realPath);
             const fileStat = await fs.stat(realPath);
 
             const options: Partial<Yazl.Options> = {


### PR DESCRIPTION
Closes: #41

**Before Fix:**
```
packaging your app... !
C:\Users\wreiske\Documents\prj\Rocket.Chat.App-Secret>rc-apps package
Error: absolute path: C:/Users/wreiske/Documents/prj/Rocket.Chat.App-Secret/app.json
    at validateMetadataPath (C:/Users/wreiske/AppData/Roaming/npm/node_modules/@rocket.chat/apps-cli/node_modules/yazl/index.js:367:74)
    at ZipFile.addFile (C:/Users/wreiske/AppData/Roaming/npm/node_modules/@rocket.chat/apps-cli/node_modules/yazl/index.js:24:18)
    at AppPackager.zipItUp (C:/Users/wreiske/AppData/Roaming/npm/node_modules/@rocket.chat/apps-cli/lib/misc/appPackager.js:43:17)
```


**After Fix:**
```
C:\Users\wreiske\Documents\prj\Rocket.Chat.App-Secret>rc-apps package
packaging your app... finished!
 
App packaged up at: C:\Users\wreiske\Documents\prj\Rocket.Chat.App-Secret\dist\secret_0.0.1.zip
```