### PR TITLE
Fix elif branch to actually show compiler errors

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -141,11 +141,10 @@ export default class Deploy extends Command {
         if (deployResult.status === 'error') {
             throw new Error(`Unknown error occurred while deploying ${JSON.stringify(deployResult)}`);
         } else if (!deployResult.success) {
-            throw new Error(`Deployment error: ${ deployResult.error }`);
-        }
-
-        if (deployResult.compilerErrors && deployResult.compilerErrors.length > 0) {
-            throw new Error(`Deployment compiler errors: \n${ JSON.stringify(deployResult.compilerErrors, null, 2) }`);
+            if (deployResult.status === 'compiler_error') {
+                throw new Error(`Deployment compiler errors: \n${ JSON.stringify(deployResult.messages, null, 2) }`);
+            }
+            throw new Error(`Deployment error: ${ deployResult }`);
         }
     }
 


### PR DESCRIPTION
When there are compiler errors, there are of this form :  

```
deploying your app... !
Error: Deployment error: {"status":"compiler_error","messages":[{"file":"/home/vagrant/Rocket.Chat/node_modules/@types/node/index.d.ts","line":165,"character":10,"message":"/home/vagrant/Rocket.Chat/node_modules/@types/node/index.d.ts (166,11): Duplicate identifier 'IteratorResult'."},{"file":"/vagrant/Rocket.Chat.Apps-engine/node_modules/typescript/lib/lib.es2015.iterable.d.ts","line":40,"character":5,"message":"/vagrant/Rocket.Chat.Apps-engine/node_modules/typescript/lib/lib.es2015.iterable.d.ts (41,6): Duplicate identifier 'IteratorResult'."}],"success":false}
```

Previous code was not able to show them.