### PR TITLE
[NEW] Support verbose option to show additional details

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -27,6 +27,10 @@ export default class Deploy extends Command {
             char: 't',
             description: 'API token to use with UserID (instead of username & password)',
         }),
+        verbose: flags.boolean({
+            char: 'v',
+            description: 'show additional details about the results of running the command',
+        }),
         userid: flags.string({
             char: 'i',
             description: 'UserID to use with API token (instead of username & password)',
@@ -63,6 +67,10 @@ export default class Deploy extends Command {
             cli.action.start(chalk.bold.greenBright('   Packaging the app'));
             const compiler = new AppCompiler(fd);
             const result = await compiler.compile();
+
+            if (flags.verbose) {
+                this.log(`${chalk.green('[info]')} using TypeScript v${ result.typeScriptVersion }`);
+            }
 
             if (result.diagnostics.length && !flags.force) {
                 this.reportDiagnostics(result.diagnostics);

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -19,6 +19,10 @@ export default class Package extends Command {
             char: 'f',
             description: 'forcefully package the App, ignores lint & TypeScript errors',
         }),
+        'verbose': flags.boolean({
+            char: 'v',
+            description: 'show additional details about the results of running the command',
+        }),
     };
 
     public async run(): Promise<void> {
@@ -39,6 +43,10 @@ export default class Package extends Command {
         const result = await compiler.compile();
 
         const { flags } = this.parse(Package);
+
+        if (flags.verbose) {
+            this.log(`${chalk.green('[info]')} using TypeScript v${ result.typeScriptVersion }`);
+        }
 
         if (result.diagnostics.length && !flags.force) {
             this.reportDiagnostics(result.diagnostics);

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -96,8 +96,7 @@ const tasks = async (command: Command, fd: FolderDetails, flags: { [key: string]
         const result = await compiler.compile();
 
         if (flags.verbose) {
-            // tslint:disable-next-line:no-console
-            console.log(`${chalk.green('[info]')} using TypeScript v${ result.typeScriptVersion }`);
+            command.log(`${chalk.green('[info]')} using TypeScript v${ result.typeScriptVersion }`);
         }
 
         if (result.diagnostics.length && !flags.force) {

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -32,6 +32,10 @@ export default class Watch extends Command {
             char: 'i',
             description: 'UserID to use with API token (instead of username & password)',
         }),
+        verbose: flags.boolean({
+            char: 'v',
+            description: 'show additional details about the results of running the command',
+        }),
         // flag with no value (-f, --force)
         force: flags.boolean({ char: 'f', description: 'forcefully deploy the App, ignores lint & TypeScript errors' }),
         code: flags.string({ char: 'c', dependsOn: ['username'], description: '2FA code of the user' }),
@@ -90,6 +94,11 @@ const tasks = async (command: Command, fd: FolderDetails, flags: { [key: string]
         cli.action.start(chalk.bold.greenBright('   Packaging the app'));
         const compiler = new AppCompiler(fd);
         const result = await compiler.compile();
+
+        if (flags.verbose) {
+            // tslint:disable-next-line:no-console
+            console.log(`${chalk.green('[info]')} using TypeScript v${ result.typeScriptVersion }`);
+        }
 
         if (result.diagnostics.length && !flags.force) {
             reportDiagnostics(command, result.diagnostics);


### PR DESCRIPTION
Provide a `verbose` option to show additional details (like typescript version) when running the commands `deploy`, `package`, and `watch`.

![image](https://user-images.githubusercontent.com/32427260/97991138-fb0fd080-1e1b-11eb-9230-f810ebfa3c1a.png)
