### PR TITLE
[IMPROVE] Updating existing app without flag

### DIFF
--- a/src/misc/deployHelpers.ts
+++ b/src/misc/deployHelpers.ts
@@ -201,6 +201,10 @@ export const asyncSubmitData = async (data: FormData, flags: { [key: string]: an
 
             authResult = { data: { authToken: flags.token, userId: flags.userId } };
         }
+    
+        if (await checkUpload(flags, fd)) {
+           flags.update = true;
+        }
 
         let endpoint = '/api/apps';
         if (flags.update) {

--- a/src/misc/deployHelpers.ts
+++ b/src/misc/deployHelpers.ts
@@ -1,4 +1,6 @@
 import Command from '@oclif/command';
+import chalk from 'chalk';
+import cli from 'cli-ux';
 import * as FormData from 'form-data';
 import * as fs from 'fs';
 import fetch from 'node-fetch';
@@ -203,7 +205,8 @@ export const asyncSubmitData = async (data: FormData, flags: { [key: string]: an
         }
 
         if (await checkUpload(flags, fd)) {
-           flags.update = true;
+            cli.log(chalk.bold.greenBright('   App already exists - updating it.'));
+            flags.update = true;
         }
 
         let endpoint = '/api/apps';

--- a/src/misc/deployHelpers.ts
+++ b/src/misc/deployHelpers.ts
@@ -201,7 +201,7 @@ export const asyncSubmitData = async (data: FormData, flags: { [key: string]: an
 
             authResult = { data: { authToken: flags.token, userId: flags.userId } };
         }
-    
+
         if (await checkUpload(flags, fd)) {
            flags.update = true;
         }


### PR DESCRIPTION
**Old behavior:** The `rc-apps` deploy commands will send a request specifically to the `/api/apps` endpoint with the new app, which errors out if the app already exists. For it to update the app, you need to explicitly use the `--update` flag.

**New behavior:** Regardless of the underlying method, the command should be able to determine what endpoint needs to be called, without requiring the `--update` flag.

Deploying a existing app **without** the `--update` flag in the new behavior:
```shell
rc-apps deploy --url http://localhost:3000 --username user --password pass 
   
   Starting App Deployment to Server

   Getting Server Info... ✓
   Packaging the app... ✓
   App already exists - updating it.
   Uploading App... ✓
```

