### PR TITLE
[IMPROVE] Add support for bundling apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -702,11 +702,12 @@
       }
     },
     "@rocket.chat/apps-compiler": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@rocket.chat/apps-compiler/-/apps-compiler-0.1.5.tgz",
-      "integrity": "sha512-ahGvmmqhahToLMtJRLUCCUxCiAcW2Ps4ml6X+x+lieMeAK4/48GETCdW65MH3UmU4sYU+xJSEeVAJg7rvOM4DA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@rocket.chat/apps-compiler/-/apps-compiler-0.2.0.tgz",
+      "integrity": "sha512-Sqpx8caCYj1fH91VBs2krXJXmA8la5/k427Is667l+5lvpOmPwD70tZ0TUq8cEBglaY6qx1vfO8b0EHU11K50g==",
       "requires": {
         "@rocket.chat/apps-engine": "^1.22.2",
+        "esbuild": "^0.12.16",
         "figures": "^3.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.4",
@@ -717,24 +718,6 @@
         "yazl": "^2.5.1"
       },
       "dependencies": {
-        "@rocket.chat/apps-engine": {
-          "version": "1.22.2",
-          "resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.22.2.tgz",
-          "integrity": "sha512-wmFy/YOF5nZRxgMvTPE4zAAGidIrePndEPFuslZc+ocsZeO3zDl6i8MT0WN0vVLM6htEOe4/O4XS2H28XCAwnw==",
-          "requires": {
-            "adm-zip": "^0.4.9",
-            "cryptiles": "^4.1.3",
-            "lodash.clonedeep": "^4.5.0",
-            "semver": "^5.5.0",
-            "stack-trace": "0.0.10",
-            "uuid": "^3.2.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
         "typescript": {
           "version": "2.9.2",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
@@ -1780,6 +1763,11 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "esbuild": {
+      "version": "0.12.28",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.28.tgz",
+      "integrity": "sha512-pZ0FrWZXlvQOATlp14lRSk1N9GkeJ3vLIwOcUoo3ICQn9WNR4rWoNi81pbn6sC1iYUy7QPqNzI3+AEzokwyVcA=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -702,11 +702,11 @@
       }
     },
     "@rocket.chat/apps-compiler": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@rocket.chat/apps-compiler/-/apps-compiler-0.2.0.tgz",
-      "integrity": "sha512-Sqpx8caCYj1fH91VBs2krXJXmA8la5/k427Is667l+5lvpOmPwD70tZ0TUq8cEBglaY6qx1vfO8b0EHU11K50g==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@rocket.chat/apps-compiler/-/apps-compiler-0.3.0.tgz",
+      "integrity": "sha512-buWUM8i5Px/oG+bACuQkNuHz+SLn6kmpG58E7/dXPU8Gst0eO77vSA/utNk2yryNEdkADTBgZ78ADxsxKLzUVw==",
       "requires": {
-        "@rocket.chat/apps-engine": "^1.22.2",
+        "@rocket.chat/apps-engine": "^1.28.0-alpha.5428",
         "esbuild": "^0.12.16",
         "figures": "^3.0.0",
         "fs-extra": "^8.1.0",
@@ -718,6 +718,24 @@
         "yazl": "^2.5.1"
       },
       "dependencies": {
+        "@rocket.chat/apps-engine": {
+          "version": "1.28.0-alpha.5428",
+          "resolved": "https://registry.npmjs.org/@rocket.chat/apps-engine/-/apps-engine-1.28.0-alpha.5428.tgz",
+          "integrity": "sha512-M2i74yj3fvOw60FssXrF+dSQ5F9U/LOa865UhJH8ijcY1lTbqku1v7gXEi4GaTZ9HSS7bV47YECCj5qQ1ENgcw==",
+          "requires": {
+            "adm-zip": "^0.4.9",
+            "cryptiles": "^4.1.3",
+            "lodash.clonedeep": "^4.5.0",
+            "semver": "^5.5.0",
+            "stack-trace": "0.0.10",
+            "uuid": "^3.2.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
         "typescript": {
           "version": "2.9.2",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
@@ -1765,9 +1783,9 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.12.28",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.28.tgz",
-      "integrity": "sha512-pZ0FrWZXlvQOATlp14lRSk1N9GkeJ3vLIwOcUoo3ICQn9WNR4rWoNi81pbn6sC1iYUy7QPqNzI3+AEzokwyVcA=="
+      "version": "0.12.29",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
+      "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@oclif/plugin-autocomplete": "^0.2.0",
     "@oclif/plugin-help": "^2.2.0",
     "@oclif/plugin-not-found": "^1.2.2",
-    "@rocket.chat/apps-compiler": "^0.1.7",
+    "@rocket.chat/apps-compiler": "^0.2.0",
     "@rocket.chat/apps-engine": "^1.12.0",
     "axios": "^0.19.0",
     "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@oclif/plugin-autocomplete": "^0.2.0",
     "@oclif/plugin-help": "^2.2.0",
     "@oclif/plugin-not-found": "^1.2.2",
-    "@rocket.chat/apps-compiler": "^0.2.0",
+    "@rocket.chat/apps-compiler": "^0.3.0",
     "@rocket.chat/apps-engine": "^1.12.0",
     "axios": "^0.19.0",
     "chalk": "^2.4.2",

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -67,15 +67,24 @@ export default class Deploy extends Command {
 
             cli.action.start(chalk.bold.greenBright('   Packaging the app'));
             const compiler = new AppCompiler(fd);
-            const result = await compiler.compile();
+            const compilationResult = await compiler.compile();
 
             if (flags.verbose) {
-                this.log(`${chalk.green('[info]')} using TypeScript v${ result.typeScriptVersion }`);
+                this.log(`${chalk.green('[info]')} using TypeScript v${ compilationResult.typeScriptVersion }`);
             }
 
-            if (result.diagnostics.length && !flags.force) {
-                this.reportDiagnostics(result.diagnostics);
+            if (compilationResult.diagnostics.length && !flags.force) {
+                this.reportDiagnostics(compilationResult.diagnostics);
                 this.error('TypeScript compiler error(s) occurred');
+                this.exit(1);
+                return;
+            }
+
+            const bundlingResult = await compiler.bundle();
+
+            if (bundlingResult.diagnostics.length && !flags.force) {
+                this.reportDiagnostics(bundlingResult.diagnostics);
+                this.error('Bundler error(s) occurred');
                 this.exit(1);
                 return;
             }

--- a/src/commands/package.ts
+++ b/src/commands/package.ts
@@ -41,17 +41,26 @@ export default class Package extends Command {
 
         const compiler = new AppCompiler(fd);
 
-        const result = await compiler.compile();
+        const compilationResult = await compiler.compile();
 
         const { flags } = this.parse(Package);
 
         if (flags.verbose) {
-            this.log(`${chalk.green('[info]')} using TypeScript v${ result.typeScriptVersion }`);
+            this.log(`${chalk.green('[info]')} using TypeScript v${ compilationResult.typeScriptVersion }`);
         }
 
-        if (result.diagnostics.length && !flags.force) {
-            this.reportDiagnostics(result.diagnostics);
+        if (compilationResult.diagnostics.length && !flags.force) {
+            this.reportDiagnostics(compilationResult.diagnostics);
             this.error('TypeScript compiler error(s) occurred');
+            this.exit(1);
+            return;
+        }
+
+        const bundlingResult = await compiler.bundle();
+
+        if (bundlingResult.diagnostics.length && !flags.force) {
+            this.reportDiagnostics(bundlingResult.diagnostics);
+            this.error('Bundler error(s) occurred');
             this.exit(1);
             return;
         }

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -42,11 +42,20 @@ export default class Submit extends Command {
         }
 
         const compiler = new AppCompiler(fd);
-        const result = await compiler.compile();
+        const compilationResult = await compiler.compile();
 
-        if (result.diagnostics.length) {
-            this.reportDiagnostics(result.diagnostics);
+        if (compilationResult.diagnostics.length) {
+            this.reportDiagnostics(compilationResult.diagnostics);
             this.error('TypeScript compiler error(s) occurred');
+            this.exit(1);
+            return;
+        }
+
+        const bundlingResult = await compiler.bundle();
+
+        if (bundlingResult.diagnostics.length) {
+            this.reportDiagnostics(bundlingResult.diagnostics);
+            this.error('Bundler error(s) occurred');
             this.exit(1);
             return;
         }

--- a/src/misc/appCompiler.ts
+++ b/src/misc/appCompiler.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import { AppsCompiler } from '@rocket.chat/apps-compiler';
-import { ICompilerResult } from '@rocket.chat/apps-compiler/definition';
+import { IBundledCompilerResult, ICompilerResult } from '@rocket.chat/apps-compiler/definition';
 
 import { FolderDetails } from './folderDetails';
 
@@ -28,11 +28,17 @@ export class AppCompiler {
             tool: packageInfo.name,
             version: packageInfo.version,
             when: new Date(),
-        }, getTypescriptForApp(fd));
+        },
+        this.fd.folder,
+        getTypescriptForApp(fd));
     }
 
     public async compile(): Promise<ICompilerResult> {
-        return this.compiler.compile(this.fd.folder);
+        return this.compiler.compile();
+    }
+
+    public async bundle(): Promise<IBundledCompilerResult> {
+        return this.compiler.bundle();
     }
 
     public async outputZip(): Promise<string> {


### PR DESCRIPTION
As the compiler now [supports bundling apps](https://github.com/RocketChat/Rocket.Chat.Apps-compiler/pull/38), the cli must also include this task in the packaging and deployment processes.

Note: this PR shouldn't be merged until the new version of the compiler [the new PR with improvements](https://github.com/RocketChat/Rocket.Chat.Apps-compiler/pull/39) gets merged as they add important developer experience adjustments.