### PR TITLE
[FIX] Passing userId with -i has no effect on deployment

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -31,7 +31,7 @@ export default class Deploy extends Command {
             char: 'v',
             description: 'show additional details about the results of running the command',
         }),
-        userid: flags.string({
+        userId: flags.string({
             char: 'i',
             description: 'UserID to use with API token (instead of username & password)',
         }),

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -28,7 +28,7 @@ export default class Watch extends Command {
             char: 't',
             description: 'API token to use with UserID (instead of username & password)',
         }),
-        userid: flags.string({
+        userId: flags.string({
             char: 'i',
             description: 'UserID to use with API token (instead of username & password)',
         }),


### PR DESCRIPTION
Closes https://github.com/RocketChat/Rocket.Chat.Apps-cli/issues/119

`userId` is being used here and its value was always null