### PR TITLE
feat: Multiple boilerplate options processing

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -27,13 +27,13 @@ export default class Generate extends Command {
         } catch (e) {
             this.error(chalk.bold.red(e && e.message ? e.message : e));
         }
-        let option = flags.options;
+        let options = flags.options ? [flags.options] : [];
         const categories = [
             'Api Extension',
             'Slash Command Extension',
             'Settings Extension',
         ];
-        if (!option) {
+        if (!options.length) {
             inquirer.registerPrompt('checkbox-plus', require('inquirer-checkbox-plus-prompt'));
             const result = await inquirer.prompt([{
                 type: 'checkbox-plus',
@@ -64,20 +64,37 @@ export default class Generate extends Command {
                     });
                 },
             }] as any);
-            option = (result as any).categories[0];
+            options = (result as any).categories;
         }
-        switch (option) {
-            case 'Api Extension':
-                this.ApiExtensionBoilerplate(fd);
-                break;
-            case 'Slash Command Extension':
-                this.SlashCommandExtension(fd);
-                break;
-            case 'Settings Extension':
-                this.SettingExtension(fd);
-                break;
-            default:
-                break;
+
+        // switch (option) {
+        //     case 'Api Extension':
+        //         this.ApiExtensionBoilerplate(fd);
+        //         break;
+        //     case 'Slash Command Extension':
+        //         this.SlashCommandExtension(fd);
+        //         break;
+        //     case 'Settings Extension':
+        //         this.SettingExtension(fd);
+        //         break;
+        //     default:
+        //         break;
+        // }
+
+        for (const option of options) {
+            switch (option) {
+                case 'Api Extension':
+                    await this.ApiExtensionBoilerplate(fd);
+                    break;
+                case 'Slash Command Extension':
+                    await this.SlashCommandExtension(fd);
+                    break;
+                case 'Settings Extension':
+                    await this.SettingExtension(fd);
+                    break;
+                default:
+                    break;
+            }
         }
 
     }


### PR DESCRIPTION
Description: This PR improves the CLI to make it easier to use when generating boilerplate templates. The following changes have been made:

- Multiple Options: The CLI can now process multiple selected options at once, allowing users to generate multiple boilerplate templates in one command.
- Short Flag Mapping: Short flags like -a, -b, -c now map to their full option names, making it faster for users to choose options.

Impact:
- Users can generate multiple boilerplate templates quickly.
- Short flags make it easier to use the CLI with fewer keystrokes.

Closes #161

Video: 

https://github.com/user-attachments/assets/100bd708-87f5-463c-9baa-932028d4ad5f

and 



https://github.com/user-attachments/assets/be7682fd-ab81-4c0a-9097-fa19a8aec916

